### PR TITLE
Resolve resource adapter product version from app model

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/ibm/mq/deployment/IbmMqProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/ibm/mq/deployment/IbmMqProcessor.java
@@ -60,13 +60,12 @@ class IbmMqProcessor {
     @BuildStep
     @Record(ExecutionTime.STATIC_INIT)
     void recordProductVersion(MQResourceAdapterRecorder recorder, CurateOutcomeBuildItem curated) {
-        String version = curated.getApplicationModel().getDependencies().stream()
+        curated.getApplicationModel().getDependencies().stream()
                 .filter(d -> "com.ibm.mq".equals(d.getGroupId())
                         && "com.ibm.mq.jakarta.connector".equals(d.getArtifactId()))
                 .map(ResolvedDependency::getVersion)
                 .findFirst()
-                .orElse("unknown");
-        recorder.setProductVersion(version);
+                .ifPresent(recorder::setProductVersion);
     }
 
     @BuildStep

--- a/deployment/src/main/java/io/quarkiverse/ibm/mq/deployment/IbmMqProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/ibm/mq/deployment/IbmMqProcessor.java
@@ -16,15 +16,20 @@ import com.ibm.msg.client.jakarta.wmq.factories.WMQComponent;
 import com.ibm.msg.client.jakarta.wmq.factories.WMQFactoryFactory;
 import com.ibm.msg.client.jakarta.wmq.factories.admin.WMQJmsFactory;
 
+import io.quarkiverse.ibm.mq.runtime.MQResourceAdapterRecorder;
 import io.quarkus.deployment.IsProduction;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import io.quarkus.deployment.dev.devservices.DevServicesConfig;
+import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.devservices.common.JBossLoggingConsumer;
+import io.quarkus.maven.dependency.ResolvedDependency;
 
 class IbmMqProcessor {
 
@@ -50,6 +55,18 @@ class IbmMqProcessor {
                 MQJMSComponent.class,
                 JMSComponent.class,
                 WMQComponent.class).constructors().methods().fields().build());
+    }
+
+    @BuildStep
+    @Record(ExecutionTime.STATIC_INIT)
+    void recordProductVersion(MQResourceAdapterRecorder recorder, CurateOutcomeBuildItem curated) {
+        String version = curated.getApplicationModel().getDependencies().stream()
+                .filter(d -> "com.ibm.mq".equals(d.getGroupId())
+                        && "com.ibm.mq.jakarta.connector".equals(d.getArtifactId()))
+                .map(ResolvedDependency::getVersion)
+                .findFirst()
+                .orElse("unknown");
+        recorder.setProductVersion(version);
     }
 
     @BuildStep

--- a/runtime/src/main/java/io/quarkiverse/ibm/mq/runtime/MQResourceAdapterFactory.java
+++ b/runtime/src/main/java/io/quarkiverse/ibm/mq/runtime/MQResourceAdapterFactory.java
@@ -35,6 +35,8 @@ public class MQResourceAdapterFactory implements ResourceAdapterFactory {
 
     private static final Logger log = Logger.getLogger(MQResourceAdapterFactory.class);
 
+    static volatile String productVersion = "unknown";
+
     @Override
     public String getProductName() {
         return "IBM MQ Resource Adapter";
@@ -42,7 +44,7 @@ public class MQResourceAdapterFactory implements ResourceAdapterFactory {
 
     @Override
     public String getProductVersion() {
-        return "9.4.4.1";
+        return productVersion;
     }
 
     @Override

--- a/runtime/src/main/java/io/quarkiverse/ibm/mq/runtime/MQResourceAdapterRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/ibm/mq/runtime/MQResourceAdapterRecorder.java
@@ -1,0 +1,11 @@
+package io.quarkiverse.ibm.mq.runtime;
+
+import io.quarkus.runtime.annotations.Recorder;
+
+@Recorder
+public class MQResourceAdapterRecorder {
+
+    public void setProductVersion(String version) {
+        MQResourceAdapterFactory.productVersion = version;
+    }
+}


### PR DESCRIPTION
Replace the hardcoded "9.4.4.1" returned by getProductVersion() with the
version of the com.ibm.mq.jakarta.connector dependency resolved from the
application model at build time. A static-init recorder writes the value
into MQResourceAdapterFactory so it stays aligned with whatever version
the user actually has on the classpath.