### PR TITLE
Use relocated quarkus-junit artifact ids

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -36,7 +36,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5-internal</artifactId>
+            <artifactId>quarkus-junit-internal</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -26,7 +26,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Summary

Quarkus 3.31 renamed the JUnit artifacts; the originals now relocate and emit a build warning:

```
[WARNING] The artifact io.quarkus:quarkus-junit5-internal:jar:3.33.1.1 has been
relocated to io.quarkus:quarkus-junit-internal:jar:3.33.1.1: Update the
artifactId in your project build file.
```

Switch:
- `deployment/pom.xml`: `quarkus-junit5-internal` → `quarkus-junit-internal`
- `integration-tests/pom.xml`: `quarkus-junit5` → `quarkus-junit`

[Quarkus 3.31 migration guide](https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.31)

## Test plan

- [x] `mvn -pl deployment,integration-tests -am clean compile test-compile` succeeds locally with no relocation warnings.
- [ ] CI `Build with Maven` and `Build with Maven (Native)` steps remain green.

---
_Generated by [Claude Code](https://claude.ai/code/session_018ba3x5hXh9rDRiPzHm5ezD)_