### PR TITLE
Use DiscoveredServiceBuilder.feature in place of deprecated name

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/ibm/mq/deployment/IbmMqProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/ibm/mq/deployment/IbmMqProcessor.java
@@ -108,7 +108,7 @@ class IbmMqProcessor {
 
         return DevServicesResultBuildItem.discovered()
                 .containerId(container.getContainerId())
-                .name("IBM MQ Dev Service")
+                .feature(FEATURE)
                 .description("IBM MQ Container")
                 .config(configOverrides)
                 .build();


### PR DESCRIPTION
## Summary

`DevServicesResultBuildItem.DiscoveredServiceBuilder.name(String)` is deprecated; the replacement is `feature(String)` / `feature(Feature)`. Reuse the existing `FEATURE = "ibm-mq"` constant so the dev service is associated with the extension feature, eliminating the build warning:

```
IbmMqProcessor.java:[111,17] name(java.lang.String) in
io.quarkus.deployment.builditem.DevServicesResultBuildItem.DiscoveredServiceBuilder
has been deprecated
```

## Test plan

- [x] `mvn -pl deployment -am compile` no longer emits the deprecation warning.
- [x] CI dev-services step still surfaces the IBM MQ container correctly.

---
_Generated by [Claude Code](https://claude.ai/code/session_018ba3x5hXh9rDRiPzHm5ezD)_