### PR TITLE
Register IBM MQ JMS native image resources and bundles

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/ibm/mq/deployment/IbmMqProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/ibm/mq/deployment/IbmMqProcessor.java
@@ -24,6 +24,8 @@ import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBundleBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import io.quarkus.deployment.dev.devservices.DevServicesConfig;
@@ -74,6 +76,32 @@ class IbmMqProcessor {
                 "com.ibm.msg.client.commonservices.workqueue.WorkQueueManager"));
         producer.produce(new RuntimeInitializedClassBuildItem(
                 "com.ibm.msg.client.commonservices.j2se.workqueue.WorkQueueManagerImplementation"));
+    }
+
+    @BuildStep
+    void registerNativeResources(BuildProducer<NativeImageResourceBuildItem> resources,
+            BuildProducer<NativeImageResourceBundleBuildItem> bundles) {
+        resources.produce(new NativeImageResourceBuildItem(
+                "META-INF/BuildInfo.properties",
+                "META-INF/ccsid_merged.map",
+                "META-INF/compinfo.properties",
+                "META-INF/IBM930ByteToChar.dat",
+                "META-INF/IBM930CharToByte.dat",
+                "META-INF/jmqiCharsets.dat",
+                "META-INF/jmqiversion.properties",
+                "META-INF/product.properties"));
+        for (String bundle : new String[] {
+                "com.ibm.mq.ese.nls.AMS_MessageResourceBundle",
+                "com.ibm.mq.jakarta.jms.admin.resources.JMSADM_MessageResourceBundle",
+                "com.ibm.mq.jakarta.jms.resources.JMSMQ_MessageResourceBundle",
+                "com.ibm.msg.client.commonservices.resources.JMSCS_MessageResourceBundle",
+                "com.ibm.msg.client.jakarta.jms.internal.resources.JMSCC_MessageResourceBundle",
+                "com.ibm.msg.client.jakarta.wmq.common.internal.resources.JMSCMQ_MessageResourceBundle",
+                "com.ibm.msg.client.jakarta.wmq.compat.jms.internal.services.resources.MQJMS_MessageResourceBundle",
+                "com.ibm.msg.client.jakarta.wmq.factories.resources.JMSFMQ_MessageResourceBundle",
+                "com.ibm.msg.client.jakarta.wmq.internal.resources.JMSWMQ_MessageResourceBundle" }) {
+            bundles.produce(new NativeImageResourceBundleBuildItem(bundle));
+        }
     }
 
     @SuppressWarnings("resource")

--- a/deployment/src/main/java/io/quarkiverse/ibm/mq/deployment/IbmMqProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/ibm/mq/deployment/IbmMqProcessor.java
@@ -90,18 +90,24 @@ class IbmMqProcessor {
                 "META-INF/jmqiCharsets.dat",
                 "META-INF/jmqiversion.properties",
                 "META-INF/product.properties"));
-        for (String bundle : new String[] {
-                "com.ibm.mq.ese.nls.AMS_MessageResourceBundle",
-                "com.ibm.mq.jakarta.jms.admin.resources.JMSADM_MessageResourceBundle",
-                "com.ibm.mq.jakarta.jms.resources.JMSMQ_MessageResourceBundle",
-                "com.ibm.msg.client.commonservices.resources.JMSCS_MessageResourceBundle",
-                "com.ibm.msg.client.jakarta.jms.internal.resources.JMSCC_MessageResourceBundle",
-                "com.ibm.msg.client.jakarta.wmq.common.internal.resources.JMSCMQ_MessageResourceBundle",
-                "com.ibm.msg.client.jakarta.wmq.compat.jms.internal.services.resources.MQJMS_MessageResourceBundle",
-                "com.ibm.msg.client.jakarta.wmq.factories.resources.JMSFMQ_MessageResourceBundle",
-                "com.ibm.msg.client.jakarta.wmq.internal.resources.JMSWMQ_MessageResourceBundle" }) {
-            bundles.produce(new NativeImageResourceBundleBuildItem(bundle));
-        }
+        bundles.produce(new NativeImageResourceBundleBuildItem(
+                "com.ibm.mq.ese.nls.AMS_MessageResourceBundle"));
+        bundles.produce(new NativeImageResourceBundleBuildItem(
+                "com.ibm.mq.jakarta.jms.admin.resources.JMSADM_MessageResourceBundle"));
+        bundles.produce(new NativeImageResourceBundleBuildItem(
+                "com.ibm.mq.jakarta.jms.resources.JMSMQ_MessageResourceBundle"));
+        bundles.produce(new NativeImageResourceBundleBuildItem(
+                "com.ibm.msg.client.commonservices.resources.JMSCS_MessageResourceBundle"));
+        bundles.produce(new NativeImageResourceBundleBuildItem(
+                "com.ibm.msg.client.jakarta.jms.internal.resources.JMSCC_MessageResourceBundle"));
+        bundles.produce(new NativeImageResourceBundleBuildItem(
+                "com.ibm.msg.client.jakarta.wmq.common.internal.resources.JMSCMQ_MessageResourceBundle"));
+        bundles.produce(new NativeImageResourceBundleBuildItem(
+                "com.ibm.msg.client.jakarta.wmq.compat.jms.internal.services.resources.MQJMS_MessageResourceBundle"));
+        bundles.produce(new NativeImageResourceBundleBuildItem(
+                "com.ibm.msg.client.jakarta.wmq.factories.resources.JMSFMQ_MessageResourceBundle"));
+        bundles.produce(new NativeImageResourceBundleBuildItem(
+                "com.ibm.msg.client.jakarta.wmq.internal.resources.JMSWMQ_MessageResourceBundle"));
     }
 
     @SuppressWarnings("resource")


### PR DESCRIPTION
## Summary

Closes #35.

The IBM MQ JMS client reads several `META-INF` data files at runtime (charset tables, version/build metadata) and resolves NLS message bundles for error/log text. Without explicit registration these are stripped from the native image, so charset conversion can hard-fail and `MQException` instances surface raw keys (`JMSCC0001` etc.) instead of localized text.

Adds a `registerNativeResources` build step covering:

**8 resource patterns** (all verified present in IBM MQ 9.4.5.1 jars):
- `META-INF/BuildInfo.properties`, `META-INF/compinfo.properties`, `META-INF/product.properties`, `META-INF/jmqiversion.properties` — build/product metadata
- `META-INF/ccsid_merged.map`, `META-INF/jmqiCharsets.dat` — charset ID maps
- `META-INF/IBM930ByteToChar.dat`, `META-INF/IBM930CharToByte.dat` — Japanese EBCDIC charset tables

**9 resource bundles** — NLS message bundles for `JMSADM`, `JMSCC`, `JMSCMQ`, `JMSCS`, `JMSFMQ`, `JMSMQ`, `JMSWMQ`, `MQJMS`, `AMS`.

Reflection types from the upstream comment are already covered by the existing `registerForReflection` step (`J2SEComponent`, `JMSComponent`, `MQJMSComponent`, `WMQComponent`), so no change there.

## Test plan

- [x] `mvn -pl deployment -am compile` succeeds.
- [ ] Native image build on this PR completes (verifies the resources and bundles resolve at image build time).
- [ ] Integration tests exercising MQ error paths show localized message text in native mode.

---
_Generated by [Claude Code](https://claude.ai/code/session_018ba3x5hXh9rDRiPzHm5ezD)_